### PR TITLE
Bump dawarich-api version to 0.1.3 and internal version

### DIFF
--- a/custom_components/dawarich/__init__.py
+++ b/custom_components/dawarich/__init__.py
@@ -5,7 +5,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 DOMAIN = "dawarich"
-VERSION = "0.2.0"
+VERSION = "0.2.1"
 
 PLATFORMS: list[Platform] = [Platform.DEVICE_TRACKER, Platform.SENSOR]
 

--- a/custom_components/dawarich/manifest.json
+++ b/custom_components/dawarich/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dawarich",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "name": "Dawarich",
   "codeowners": ["@albinlind"],
   "config_flow": true,
@@ -8,7 +8,7 @@
   "documentation": "",
   "homekit": {},
   "iot_class": "local_polling",
-  "requirements": ["dawarich-api==0.1.2"],
+  "requirements": ["dawarich-api==0.1.3"],
   "ssdp": [],
   "zeroconf": []
 }


### PR DESCRIPTION
Fixes issue #2 where we were using `datetime.date` instead of the more correct `datetime.datetime`