### PR TITLE
Add battery level parameter to device tracker optional parameters

### DIFF
--- a/custom_components/dawarich/device_tracker.py
+++ b/custom_components/dawarich/device_tracker.py
@@ -127,6 +127,9 @@ class DawarichDeviceTracker(TrackerEntity):
         if (vertical_accuracy := new_data.get("vertical_accuracy")) is not None:
             optional_params["vertical_accuracy"] = vertical_accuracy
             
+        if (battery := new_data.get("battery_level")) is not None:
+            optional_params["battery_level"] = battery
+            
         if (speed := new_data.get("speed")) is not None:
             optional_params["speed"] = speed
 


### PR DESCRIPTION
Introduce an optional battery level parameter to the DawarichDeviceTracker for enhanced state tracking.