### PR TITLE
Bump version in manifest.json

### DIFF
--- a/custom_components/dawarich/manifest.json
+++ b/custom_components/dawarich/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dawarich",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "name": "Dawarich",
   "codeowners": ["@albinlind"],
   "config_flow": true,


### PR DESCRIPTION
The version was not bumped before the last release. Integration page in HA will still show version 0.3.2.