### PR TITLE
Revert "Convert speed from m/s to km/h in DawarichDeviceTracker"

### DIFF
--- a/custom_components/dawarich/device_tracker.py
+++ b/custom_components/dawarich/device_tracker.py
@@ -131,8 +131,7 @@ class DawarichDeviceTracker(TrackerEntity):
             optional_params["battery_level"] = battery
             
         if (speed := new_data.get("speed")) is not None:
-            # Convert speed from m/s to km/h
-            optional_params["speed"] = round(speed * 3.6)
+            optional_params["speed"] = speed
 
         # Send to Dawarich API
         response = await self._api.add_one_point(


### PR DESCRIPTION
Reverts AlbinLind/dawarich-home-assistant#20
Assumption Dawarich uses km/h is wrong, change it back to m/s.
https://github.com/Freika/dawarich/issues/700