### PR TITLE
Fix en translation and bump version

### DIFF
--- a/custom_components/dawarich/manifest.json
+++ b/custom_components/dawarich/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/AlbinLind/dawarich-home-assistant/issues",
   "requirements": ["dawarich-api==0.3.0"],
   "ssdp": [],
-  "version": "0.6.0",
+  "version": "0.6.2",
   "zeroconf": []
 }

--- a/custom_components/dawarich/translations/en.json
+++ b/custom_components/dawarich/translations/en.json
@@ -39,7 +39,7 @@
         "name": "Total Reverse Geocoded",
         "unit_of_measurement": "points"
       },
-      "total_countries_visied": {
+      "total_countries_visited": {
         "name": "Total Countries Visited",
         "unit_of_measurement": "countries"
       },


### PR DESCRIPTION
Noticed unit was missing after I got a repair action from statistics, changed from "countries" to "".