### PR TITLE
feat: add velocity as speed alternative

### DIFF
--- a/custom_components/dawarich/sensor.py
+++ b/custom_components/dawarich/sensor.py
@@ -218,6 +218,8 @@ class DawarichTrackerSensor(SensorEntity):
 
         if (speed := new_data.get("speed")) is not None:
             optional_params["speed"] = speed
+        elif (velocity := new_data.get("velocity")) is not None:
+            optional_params["speed"] = velocity
 
         if (battery := new_data.get("battery")) is not None:
             optional_params["battery"] = battery


### PR DESCRIPTION
My `device_tracker` entity is using MQTT (OwnTracks) and contains a `velocity` setting for the speed. 
This value is not passed on to Dawarich because this integration is looking for `speed`.

I've made a small change to the sensor to include support for this with the following in mind:

* If `speed` exists and is not None, it takes priority.
* If `speed` is not present or is None, but `velocity` is, then `velocity` is used instead (mapped to `speed`).