### PR TITLE
Added workflow to publish the integration as a ZIP file to enable tracking download counts

### DIFF
--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -1,0 +1,31 @@
+name: Publish ZIP to GitHub Release
+
+on:
+  release:
+    types: [published]
+
+defaults:
+  run:
+    working-directory: custom_components/dawarich
+
+jobs:
+  publish:
+    name: "Publish"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: "Zip component"
+        run: |
+          zip dawarich.zip -r ./
+
+      - name: "Upload assets"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} dawarich.zip

--- a/custom_components/dawarich/manifest.json
+++ b/custom_components/dawarich/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/AlbinLind/dawarich-home-assistant/issues",
   "requirements": ["dawarich-api==0.4.1"],
   "ssdp": [],
-  "version": "0.8.3",
+  "version": "0.8.4",
   "zeroconf": []
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,3 +1,5 @@
 {
-	"name": "Dawarich"
+  "name": "Dawarich",
+  "zip_release": true,
+  "filename": "dawarich.zip"
 }


### PR DESCRIPTION
This PR adds support for a download counter for the integration in HACS. This is done by publishing the integration as a ZIP file and pointing HASS to that ZIP file.

Changelog:
- Added a workflow that archives `custom_components/dawarich` and attaches it to the release
- Updated the `hacs.json` file to point to the exported ZIP file
- Bumped the version to `0.8.4`

I've reused the code from [my integration](https://github.com/Nedevski/hass_kat_bulgaria), so it should work without further changes.