### PR TITLE
Switch entry from device to service

### DIFF
--- a/custom_components/dawarich/manifest.json
+++ b/custom_components/dawarich/manifest.json
@@ -1,15 +1,19 @@
 {
   "domain": "dawarich",
   "name": "Dawarich",
-  "codeowners": ["@albinlind"],
+  "codeowners": [
+    "@albinlind"
+  ],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/AlbinLind/dawarich-home-assistant",
   "homekit": {},
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/AlbinLind/dawarich-home-assistant/issues",
-  "requirements": ["dawarich-api==0.5.0"],
+  "requirements": [
+    "dawarich-api==0.5.0"
+  ],
   "ssdp": [],
-  "version": "1.0.0-beta2",
+  "version": "refs/heads/switch-entry-from-device-to-service",
   "zeroconf": []
 }

--- a/custom_components/dawarich/manifest.json
+++ b/custom_components/dawarich/manifest.json
@@ -14,6 +14,6 @@
     "dawarich-api==0.5.0"
   ],
   "ssdp": [],
-  "version": "refs/heads/switch-entry-from-device-to-service",
+  "version": "1.0.0-beta2",
   "zeroconf": []
 }

--- a/custom_components/dawarich/sensor.py
+++ b/custom_components/dawarich/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.issue_registry import (
@@ -104,6 +104,7 @@ async def async_setup_entry(
         name=name,
         manufacturer="Dawarich",
         configuration_url=entry.runtime_data.api.url,
+        entry_type=DeviceEntryType.SERVICE,
     )
 
     # Add statistics sensor


### PR DESCRIPTION
I've modified the `DeviceInfo` in `sensor.py` to mark Dawarich entries as services instead of devices. The changes made:

1. Added import for `DeviceEntryType` from `homeassistant.helpers.device_registry`
2. Added `entry_type=DeviceEntryType.SERVICE` parameter to the `DeviceInfo` constructor

After reloading the integration in Home Assistant, the Dawarich entries will now appear as services in the device registry instead of devices.

### Screenshots before
<img width="425" height="281" alt="Screenshot 2026-03-07 135347" src="https://github.com/user-attachments/assets/f055c961-f07d-40af-adb8-c22c370f63c9" />
<img width="535" height="158" alt="Screenshot 2026-03-07 135406" src="https://github.com/user-attachments/assets/61fbd342-90e3-4fbc-88ca-647de7ae5729" />

### Screenshots after
<img width="429" height="273" alt="Screenshot 2026-03-07 135501" src="https://github.com/user-attachments/assets/470c31ff-d7e1-40cf-9a35-a6c4009c0381" />
<img width="548" height="151" alt="Screenshot 2026-03-07 135445" src="https://github.com/user-attachments/assets/1e4e0a77-040e-4a6c-86f5-e5e0e1e9093f" />
