### PR TITLE
Added support for a minimum distance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Below are the configuration options for the Dawarich Home Assistant integration.
 - **Port:** port number for host
 - **Name:** integration entry category to contain devices
 - **Device Tracker:** device tracker to send data to Dawarich
+- **Minimum distance change:** minimum distance in meters that must be changed before sending location to Dawarich
 - **Use SSL:** check to use HTTPS (i.e. prepends url with `https`)
 - **Verify SSL:** make sure secure connection is made through SSL
 

--- a/custom_components/dawarich/__init__.py
+++ b/custom_components/dawarich/__init__.py
@@ -19,7 +19,12 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_DEVICE, DOMAIN
+from .const import (
+    CONF_DEVICE,
+    CONF_MIN_DISTANCE,
+    DEFAULT_MIN_DISTANCE,
+    DOMAIN,
+)
 from .coordinator import DawarichStatsCoordinator, DawarichVersionCoordinator
 from .helpers import get_api
 
@@ -84,10 +89,10 @@ async def async_unload_entry(
     return unload_ok
 
 
-# Migration from 1 to 2
+# Migration from 1 to 2 to 3
 async def async_migrate_entry(hass: HomeAssistant, entry: config_entries.ConfigEntry):
     """Migrate an old entry."""
-    if entry.version > 1:
+    if entry.version > 2:
         # Downgrade not supported
         return False
 
@@ -115,6 +120,13 @@ async def async_migrate_entry(hass: HomeAssistant, entry: config_entries.ConfigE
         data[CONF_DEVICE] = entry.data.get("mobile_app", None)
 
         hass.config_entries.async_update_entry(entry, data=data, version=2)
+
+    if entry.version == 2:
+        new_data = {**entry.data}
+        if CONF_MIN_DISTANCE not in new_data:
+            new_data[CONF_MIN_DISTANCE] = DEFAULT_MIN_DISTANCE
+
+        hass.config_entries.async_update_entry(entry, data=new_data, version=3)
 
     _LOGGER.info("Migrated %s to config flow version %s", entry.entry_id, entry.version)
     return True

--- a/custom_components/dawarich/config_flow.py
+++ b/custom_components/dawarich/config_flow.py
@@ -18,6 +18,8 @@ from homeassistant.helpers import selector
 
 from .const import (
     CONF_DEVICE,
+    CONF_MIN_DISTANCE,
+    DEFAULT_MIN_DISTANCE,
     DEFAULT_NAME,
     DEFAULT_PORT,
     DEFAULT_SSL,
@@ -32,7 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 class DawarichConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Dawarich."""
 
-    VERSION = 2
+    VERSION = 3
 
     def __init__(self) -> None:
         """Initialize Dawarich config flow."""
@@ -52,6 +54,9 @@ class DawarichConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_SSL: user_input[CONF_SSL],
                 CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
                 CONF_DEVICE: user_input.get(CONF_DEVICE),
+                CONF_MIN_DISTANCE: user_input.get(
+                    CONF_MIN_DISTANCE, DEFAULT_MIN_DISTANCE
+                ),
             }
 
             self._async_abort_entries_match(
@@ -95,6 +100,10 @@ class DawarichConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_VERIFY_SSL,
                         default=user_input.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
                     ): bool,
+                    vol.Required(
+                        CONF_MIN_DISTANCE,
+                        default=user_input.get(CONF_MIN_DISTANCE, DEFAULT_MIN_DISTANCE),
+                    ): vol.Coerce(int),
                 }
             ),
             errors=errors,
@@ -215,6 +224,9 @@ class DawarichConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_SSL: user_input[CONF_SSL],
                 CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
                 CONF_DEVICE: user_input.get(CONF_DEVICE),
+                CONF_MIN_DISTANCE: user_input.get(
+                    CONF_MIN_DISTANCE, DEFAULT_MIN_DISTANCE
+                ),
                 CONF_API_KEY: new_api_key,
             }
 
@@ -233,6 +245,9 @@ class DawarichConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_NAME: current_data.get(CONF_NAME, DEFAULT_NAME),
                 CONF_SSL: current_data.get(CONF_SSL, DEFAULT_SSL),
                 CONF_VERIFY_SSL: current_data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+                CONF_MIN_DISTANCE: current_data.get(
+                    CONF_MIN_DISTANCE, DEFAULT_MIN_DISTANCE
+                ),
             }
 
         return self.async_show_form(
@@ -269,6 +284,10 @@ class DawarichConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_API_KEY,
                         description={"suggested_value": ""},
                     ): str,
+                    vol.Optional(
+                        CONF_MIN_DISTANCE,
+                        default=user_input.get(CONF_MIN_DISTANCE),
+                    ): vol.Coerce(int),
                 }
             ),
             errors=errors,

--- a/custom_components/dawarich/const.py
+++ b/custom_components/dawarich/const.py
@@ -10,7 +10,9 @@ DEFAULT_PORT = 80
 DEFAULT_NAME = "Dawarich"
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
+DEFAULT_MIN_DISTANCE = 0
 CONF_DEVICE = "mobile_app"
+CONF_MIN_DISTANCE = "min_distance"
 UPDATE_INTERVAL = timedelta(seconds=60)
 VERSION_UPDATE_INTERVAL = timedelta(hours=1)
 

--- a/custom_components/dawarich/sensor.py
+++ b/custom_components/dawarich/sensor.py
@@ -26,10 +26,17 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
+from homeassistant.util.location import distance
 
 from custom_components.dawarich import DawarichConfigEntry
 
-from .const import CONF_DEVICE, DOMAIN, DawarichTrackerStates
+from .const import (
+    CONF_DEVICE,
+    CONF_MIN_DISTANCE,
+    DEFAULT_MIN_DISTANCE,
+    DOMAIN,
+    DawarichTrackerStates,
+)
 from .coordinator import DawarichStatsCoordinator, DawarichVersionCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -125,6 +132,7 @@ async def async_setup_entry(
 
     # Add (optional) mobile app tracker sensor
     mobile_app = entry.data[CONF_DEVICE]
+    min_distance_val = entry.data.get(CONF_MIN_DISTANCE, DEFAULT_MIN_DISTANCE)
     if mobile_app is not None:
         _LOGGER.info("Adding tracker sensor for %s", mobile_app)
         api = entry.runtime_data.api
@@ -137,6 +145,7 @@ async def async_setup_entry(
                 hass=hass,
                 device_info=device_info,
                 description=TRACKER_SENSOR_TYPES,
+                min_distance=min_distance_val,
             )
         )
     else:
@@ -157,6 +166,7 @@ class DawarichTrackerSensor(SensorEntity):
         hass: HomeAssistant,
         device_info: DeviceInfo,
         description: SensorEntityDescription,
+        min_distance: int,
     ) -> None:
         """Initialize the sensor."""
         self._device_name = device_name
@@ -168,6 +178,9 @@ class DawarichTrackerSensor(SensorEntity):
         self._attr_device_class = description.device_class
         self.entity_description = description
         self._repair_issue_created = False
+        self._min_distance = min_distance
+        self._last_lat: float | None = None
+        self._last_lon: float | None = None
 
         self._async_unsubscribe_state_changed = async_track_state_change_event(
             hass=self._hass,
@@ -284,6 +297,21 @@ class DawarichTrackerSensor(SensorEntity):
             _LOGGER.debug("Coordinates are not present, skipping update")
             return
 
+        # Check distance if min_distance is set
+        if (
+            self._min_distance > 0
+            and self._last_lat is not None
+            and self._last_lon is not None
+        ):
+            diff = distance(self._last_lat, self._last_lon, latitude, longitude)
+            if diff < self._min_distance:
+                _LOGGER.debug(
+                    "Distance change (%s) is less than minimum distance (%s), skipping update",
+                    diff,
+                    self._min_distance,
+                )
+                return
+
         optional_params = await self._async_add_optional_params(new_data)
 
         # Send to Dawarich API
@@ -296,6 +324,8 @@ class DawarichTrackerSensor(SensorEntity):
         if response.success:
             _LOGGER.debug("Location sent to Dawarich API")
             self._state = DawarichTrackerStates.SUCCESS
+            self._last_lat = latitude
+            self._last_lon = longitude
         else:
             self._state = DawarichTrackerStates.ERROR
             _LOGGER.error(

--- a/custom_components/dawarich/strings.json
+++ b/custom_components/dawarich/strings.json
@@ -37,7 +37,8 @@
           "mobile_app": "Device Tracker",
           "ssl": "Use SSL (i.e. https)",
           "verify_ssl": "Verify SSL",
-          "api_key": "API Key (leave empty to keep current)"
+          "api_key": "API Key (leave empty to keep current)",
+          "min_distance": "Minimum distance change (meters)"
         }
       }
     },

--- a/custom_components/dawarich/translations/de.json
+++ b/custom_components/dawarich/translations/de.json
@@ -37,7 +37,8 @@
           "mobile_app": "Geräte Tracker",
           "ssl": "SSL gebrauchen (z.B. https)",
           "verify_ssl": "SSL verifizieren",
-          "api_key": "API Schlüssel (leer lassen um aktuellen zu behalten)"
+          "api_key": "API Schlüssel (leer lassen um aktuellen zu behalten)",
+          "min_distance": "Mindestentfernung vom letzten Punkt für ein erneutes Update (in Metern)"
         }
       }
     },

--- a/custom_components/dawarich/translations/en.json
+++ b/custom_components/dawarich/translations/en.json
@@ -38,7 +38,7 @@
           "ssl": "Use SSL (i.e. https)",
           "verify_ssl": "Verify SSL",
           "api_key": "API Key (leave empty to keep current)",
-          "min_distance": "Minimum distance change (meters)"
+          "min_distance": "Minimum distance change from last point for a new update (meters)"
         }
       }
     },

--- a/custom_components/dawarich/translations/en.json
+++ b/custom_components/dawarich/translations/en.json
@@ -37,7 +37,8 @@
           "mobile_app": "Device Tracker",
           "ssl": "Use SSL (i.e. https)",
           "verify_ssl": "Verify SSL",
-          "api_key": "API Key (leave empty to keep current)"
+          "api_key": "API Key (leave empty to keep current)",
+          "min_distance": "Minimum distance change (meters)"
         }
       }
     },


### PR DESCRIPTION
I've added support for a minimum distance option during integration setup. This allows you to set a threshold in meters (defaulting to 0) that must be met before a new location point is sent to Dawarich.

By requiring a minimum distance from the last recorded point, this can significantly reduce load and data usage on the dawarich instance and its used reverse-geocoding api especially when using high-frequency polling in Home Assistant. This filters out the static points that pile up when a homeassistant tracker/device is rather stationary or only moves a slight irrelevant amount.

Thanks for the integration btw.