### PR TITLE
Allow selecting Person during reconfig

### DIFF
--- a/custom_components/dawarich/config_flow.py
+++ b/custom_components/dawarich/config_flow.py
@@ -255,7 +255,9 @@ class DawarichConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_DEVICE,
                         description={"suggested_value": current_data.get(CONF_DEVICE)},
                     ): selector.EntitySelector(
-                        selector.EntitySelectorConfig(domain="device_tracker")
+                        selector.EntitySelectorConfig(
+                            domain=["device_tracker", "person"],
+                        )
                     ),
                     vol.Required(
                         CONF_SSL,


### PR DESCRIPTION
Hello, 

I was trying out the latest beta5 release and I noticed that during the reconfiguration flow you can only select a device and not a person like you can in the initial config.
This PR should fix that, made it look the same as the config flow.