### PR TITLE
Source type could also be source

### DIFF
--- a/custom_components/dawarich/sensor.py
+++ b/custom_components/dawarich/sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.device_tracker.const import (
     ATTR_SOURCE_TYPE,
     SourceType,
 )
+from homeassistant.components.person.const import PersonEntityStateAttribute
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
@@ -279,7 +280,10 @@ class DawarichTrackerSensor(SensorEntity):
 
         # Check if the coordinates are present
         if latitude is None or longitude is None:
-            if new_data.get(ATTR_SOURCE_TYPE) != SourceType.GPS:
+            source_type = new_data.get(ATTR_SOURCE_TYPE)
+            if source_type is None:
+                source_type = new_data.get(PersonEntityStateAttribute.SOURCE)
+            if source_type != SourceType.GPS:
                 _LOGGER.warning(
                     (
                         "The choosen device tracker (%s) is emitting a '%s' "
@@ -287,7 +291,7 @@ class DawarichTrackerSensor(SensorEntity):
                         "Please change the device tracker to one that provides GPS coordinates."
                     ),
                     self._mobile_app,
-                    new_data.get(ATTR_SOURCE_TYPE),
+                    source_type,
                 )
             _LOGGER.debug("Coordinates are not present, skipping update")
             return


### PR DESCRIPTION
For person device trackers, the key is `source`, not `source_type` as it is for many other device trackers.